### PR TITLE
fzf-maccy.sh: restrict results to specific ZTYPEs

### DIFF
--- a/fzf-maccy.sh
+++ b/fzf-maccy.sh
@@ -5,7 +5,7 @@ set -eu -o pipefail
 DB=~/Library/Containers/org.p0deje.Maccy/Data/Library/Application\ Support/Maccy/Storage.sqlite
 SQL="select   distinct ZVALUE
      from     ZHISTORYITEMCONTENT
-     where    ZTYPE like '%text%'
+     where    ZTYPE IN ('public.text','public.utf8-plain-text')
      order by Z_PK desc"
 
 if ! [ -r "$DB" ]; then


### PR DESCRIPTION
there are other text ZTYPEs, e.g. public.utf16-external-plain-text, which
should probably be excluded from display, as they don't correspond to
user-visible entries in maccy's history:

```
sqlite> select ztype, zvalue, hex(ZVALUE) from ZHISTORYITEMCONTENT where z_pk = 2445;
public.utf16-external-plain-text|s|FFFE73006500740020002D006700200040[...]
```